### PR TITLE
Fix nullability warnings

### DIFF
--- a/src/NullabilityInfo/NullabilityInfo.cs.pp
+++ b/src/NullabilityInfo/NullabilityInfo.cs.pp
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Collections.ObjectModel;
 
 namespace System.Reflection

--- a/src/NullabilityInfo/NullabilityInfoContext.cs.pp
+++ b/src/NullabilityInfo/NullabilityInfoContext.cs.pp
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 

--- a/src/NullabilityInfo/NullabilityInfoExtensions.cs.pp
+++ b/src/NullabilityInfo/NullabilityInfoExtensions.cs.pp
@@ -1,4 +1,6 @@
-﻿using System.Collections.Concurrent;
+﻿#nullable enable
+
+using System.Collections.Concurrent;
 
 namespace System.Reflection
 {

--- a/src/NullabilityInfo/Patching.cs.pp
+++ b/src/NullabilityInfo/Patching.cs.pp
@@ -1,4 +1,6 @@
-﻿namespace System.Reflection
+﻿#nullable enable
+
+namespace System.Reflection
 {
     class SR
     {


### PR DESCRIPTION
This fixes the following warnings in several places if the consuming project does not define <Nullable>enable</Nullable>:
> [CS8632] The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.

Note that this is not technically required in all *.pp files (only required in NullabilityInfo.cs and NullabilityInfoContext.cs) but it doesn't hurt to explicitly specify it should nullable reference types be used in the future.