### PR TITLE
Throw MissingMemberException instead of Exception

### DIFF
--- a/src/NullabilityInfo/Patching.cs.pp
+++ b/src/NullabilityInfo/Patching.cs.pp
@@ -1,4 +1,4 @@
-﻿namespace System.Reflection
+namespace System.Reflection
 {
     class SR
     {
@@ -20,7 +20,7 @@
                 }
             }
 
-            throw new($"Member not found:{member.Name}");
+            throw new MissingMemberException(type.FullName, member.Name);
         }
 
         //https://github.com/dotnet/runtime/blob/main/src/coreclr/System.Private.CoreLib/src/System/Reflection/MemberInfo.Internal.cs


### PR DESCRIPTION
There's a dedicated exception for a missing member, so use it instead of the generic `Exception`.